### PR TITLE
Move Firebase config to dotenv file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+APIKEY=your-api-key
+AUTHDOMAIN=your-auth-domain
+PROJECTID=your-project-id
+STORAGEBUCKET=your-storage-bucket
+MESSAGINGSENDERID=your-messaging-sender-id
+APPID=your-app-id
+MEASUREMENTID=your-measurement-id

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npm install
    ```
 
-2. Start the app
+2. Copy the `.env.example` file to `.env` and add your Firebase credentials:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Start the app
 
    ```bash
    npx expo start

--- a/app.config.js
+++ b/app.config.js
@@ -1,52 +1,53 @@
-{
-  "expo": {
-    "name": "workly-pro",
-    "slug": "workly-pro",
-    "version": "1.0.0",
-    "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
-    "scheme": "worklypro",
-    "userInterfaceStyle": "automatic",
-    "newArchEnabled": true,
-    "ios": {
-      "supportsTablet": true
-    },
-    "android": {
-      "adaptiveIcon": {
-        "foregroundImage": "./assets/images/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
-      },
-      "edgeToEdgeEnabled": true
-    },
-    "web": {
-      "bundler": "metro",
-      "output": "static",
-      "favicon": "./assets/images/favicon.png"
-    },
-    "plugins": [
-      "expo-router",
-      [
-        "expo-splash-screen",
-        {
-          "image": "./assets/images/splash-icon.png",
-          "imageWidth": 200,
-          "resizeMode": "contain",
-          "backgroundColor": "#ffffff"
-        }
-      ]
-    ],
-    "experiments": {
-      "typedRoutes": true
-    },
-    "extra":{
-      "APIKEY": "AIzaSyDpj9LMWfy1b45adVLyaaPr2CKJANIvRQI",
-      "AUTHDOMAIN": "workly-59281.firebaseapp.com",
-      "PROJECTID": "workly-59281",
-      "STORAGEBUCKET": "workly-59281.firebasestorage.app",
-      "MESSAGINGSENDERID": "275589312956",
-      "APPID": "1:275589312956:web:5720fa337c9cc3b0873bb9",
-      "MEASUREMENTID": "G-W60LMJQJ6L"
-    }
+import 'dotenv/config';
 
-  }
-}
+export default {
+  expo: {
+    name: 'workly-pro',
+    slug: 'workly-pro',
+    version: '1.0.0',
+    orientation: 'portrait',
+    icon: './assets/images/icon.png',
+    scheme: 'worklypro',
+    userInterfaceStyle: 'automatic',
+    newArchEnabled: true,
+    ios: {
+      supportsTablet: true,
+    },
+    android: {
+      adaptiveIcon: {
+        foregroundImage: './assets/images/adaptive-icon.png',
+        backgroundColor: '#ffffff',
+      },
+      edgeToEdgeEnabled: true,
+    },
+    web: {
+      bundler: 'metro',
+      output: 'static',
+      favicon: './assets/images/favicon.png',
+    },
+    plugins: [
+      'expo-router',
+      [
+        'expo-splash-screen',
+        {
+          image: './assets/images/splash-icon.png',
+          imageWidth: 200,
+          resizeMode: 'contain',
+          backgroundColor: '#ffffff',
+        },
+      ],
+    ],
+    experiments: {
+      typedRoutes: true,
+    },
+    extra: {
+      APIKEY: process.env.APIKEY,
+      AUTHDOMAIN: process.env.AUTHDOMAIN,
+      PROJECTID: process.env.PROJECTID,
+      STORAGEBUCKET: process.env.STORAGEBUCKET,
+      MESSAGINGSENDERID: process.env.MESSAGINGSENDERID,
+      APPID: process.env.APPID,
+      MEASUREMENTID: process.env.MEASUREMENTID,
+    },
+  },
+};

--- a/utils/firebaseconfig.ts
+++ b/utils/firebaseconfig.ts
@@ -1,22 +1,17 @@
-// Import the functions you need from the SDKs you need
-import { getAnalytics } from "firebase/analytics";
-import { initializeApp } from "firebase/app";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
-
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
-import Constants from "expo-constants";
+import { initializeApp } from 'firebase/app';
+import { getAnalytics } from 'firebase/analytics';
+import Constants from 'expo-constants';
 
 const firebaseConfig = {
-  apiKey: Constants.expoConfig.extra.APIKEY,
-  authDomain: ,
-  projectId: ,
-  storageBucket: ,
-  messagingSenderId:,
-  appId: ,
-  measurementId: 
+  apiKey: Constants.expoConfig?.extra?.APIKEY,
+  authDomain: Constants.expoConfig?.extra?.AUTHDOMAIN,
+  projectId: Constants.expoConfig?.extra?.PROJECTID,
+  storageBucket: Constants.expoConfig?.extra?.STORAGEBUCKET,
+  messagingSenderId: Constants.expoConfig?.extra?.MESSAGINGSENDERID,
+  appId: Constants.expoConfig?.extra?.APPID,
+  measurementId: Constants.expoConfig?.extra?.MEASUREMENTID,
+};
 
 // Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
+export const app = initializeApp(firebaseConfig);
+export const analytics = getAnalytics(app);


### PR DESCRIPTION
## Summary
- load env variables using `dotenv` in app.config.js
- read firebase credentials from expo config in `firebaseconfig.ts`
- provide `.env.example` and ignore real env files
- document copying `.env.example` in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b892bf68832485f5365fdccab78e