### PR TITLE
Add basic Firebase auth screens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ STORAGEBUCKET=your-storage-bucket
 MESSAGINGSENDERID=your-messaging-sender-id
 APPID=your-app-id
 MEASUREMENTID=your-measurement-id
+GOOGLE_EXPO_CLIENT_ID=your-expo-client-id
+GOOGLE_IOS_CLIENT_ID=your-ios-client-id
+GOOGLE_ANDROID_CLIENT_ID=your-android-client-id
+GOOGLE_WEB_CLIENT_ID=your-web-client-id

--- a/app.config.js
+++ b/app.config.js
@@ -48,6 +48,10 @@ export default {
       MESSAGINGSENDERID: process.env.MESSAGINGSENDERID,
       APPID: process.env.APPID,
       MEASUREMENTID: process.env.MEASUREMENTID,
+      GOOGLE_EXPO_CLIENT_ID: process.env.GOOGLE_EXPO_CLIENT_ID,
+      GOOGLE_IOS_CLIENT_ID: process.env.GOOGLE_IOS_CLIENT_ID,
+      GOOGLE_ANDROID_CLIENT_ID: process.env.GOOGLE_ANDROID_CLIENT_ID,
+      GOOGLE_WEB_CLIENT_ID: process.env.GOOGLE_WEB_CLIENT_ID,
     },
   },
 };

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,45 @@
-import { Text, View } from "react-native";
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import { app } from '@/utils/firebaseconfig';
+import { getAuth, onAuthStateChanged, signOut, User } from 'firebase/auth';
 
 export default function Index() {
+  const router = useRouter();
+  const auth = getAuth(app);
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      if (!u) router.replace('/login');
+    });
+    return unsub;
+  }, [auth, router]);
+
+  const logout = async () => {
+    await signOut(auth);
+  };
+
+  if (!user) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
+
   return (
     <View
       style={{
         flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
+        justifyContent: 'center',
+        alignItems: 'center',
       }}
     >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
+      <Text>Welcome {user.email}</Text>
+      <View style={{ height: 12 }} />
+      <Button title="Logout" onPress={logout} />
     </View>
   );
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,85 @@
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Button, Text, TextInput, View } from 'react-native';
+import { app } from '@/utils/firebaseconfig';
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  onAuthStateChanged,
+  signInWithCredential,
+  GoogleAuthProvider,
+} from 'firebase/auth';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import Constants from 'expo-constants';
+
+WebBrowser.maybeCompleteAuthSession();
+
+export default function Login() {
+  const router = useRouter();
+  const auth = getAuth(app);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    expoClientId: Constants.expoConfig?.extra?.GOOGLE_EXPO_CLIENT_ID,
+    iosClientId: Constants.expoConfig?.extra?.GOOGLE_IOS_CLIENT_ID,
+    androidClientId: Constants.expoConfig?.extra?.GOOGLE_ANDROID_CLIENT_ID,
+    webClientId: Constants.expoConfig?.extra?.GOOGLE_WEB_CLIENT_ID,
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token, access_token } = response.params;
+      const credential = GoogleAuthProvider.credential(id_token, access_token);
+      signInWithCredential(auth, credential).catch((e) => setError(e.message));
+    }
+  }, [response, auth]);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      if (u) router.replace('/');
+    });
+    return unsub;
+  }, [auth, router]);
+
+  const login = async () => {
+    setError('');
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      router.replace('/');
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        style={{ borderWidth: 1, marginBottom: 12, padding: 8 }}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={{ borderWidth: 1, marginBottom: 12, padding: 8 }}
+      />
+      {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}
+      <Button title="Login" onPress={login} />
+      <View style={{ height: 12 }} />
+      <Button
+        title="Login with Google"
+        disabled={!request}
+        onPress={() => promptAsync()}
+      />
+      <View style={{ height: 12 }} />
+      <Button title="Register" onPress={() => router.push('/register')} />
+    </View>
+  );
+}

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -1,0 +1,46 @@
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Button, Text, TextInput, View } from 'react-native';
+import { app } from '@/utils/firebaseconfig';
+import { getAuth, createUserWithEmailAndPassword } from 'firebase/auth';
+
+export default function Register() {
+  const router = useRouter();
+  const auth = getAuth(app);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const register = async () => {
+    setError('');
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+      router.replace('/');
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <TextInput
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        style={{ borderWidth: 1, marginBottom: 12, padding: 8 }}
+      />
+      <TextInput
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        style={{ borderWidth: 1, marginBottom: 12, padding: 8 }}
+      />
+      {error ? <Text style={{ color: 'red' }}>{error}</Text> : null}
+      <Button title="Create account" onPress={register} />
+      <View style={{ height: 12 }} />
+      <Button title="Back to Login" onPress={() => router.back()} />
+    </View>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.1.6",
         "dotenv": "^16.5.0",
         "expo": "~53.0.9",
+        "expo-auth-session": "^6.1.5",
         "expo-blur": "~14.1.4",
         "expo-constants": "~17.1.6",
         "expo-font": "~13.3.1",
@@ -6918,6 +6919,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-6.1.4.tgz",
+      "integrity": "sha512-jXVZb3llTQ5j4C/I03GxKjujmhKex9Xo5JDZo/pRjScHSr4NoeMjPKWThyWVlWDM1v5YSEcsRJebVfTvq9SR5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.5.tgz",
@@ -6929,6 +6939,24 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-auth-session": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-6.1.5.tgz",
+      "integrity": "sha512-KvXWpufwIjze5W9TdX4CqCLm4SAtjBEHvMPE/7CiX6ThB583ckpoo1mgzKGNyrKl7p7eKcdZmHcmXJYldXugkA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-application": "~6.1.4",
+        "expo-constants": "~17.1.4",
+        "expo-crypto": "~14.1.4",
+        "expo-linking": "~7.1.4",
+        "expo-web-browser": "~14.1.6",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }
@@ -6956,6 +6984,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-14.1.4.tgz",
+      "integrity": "sha512-RmKhB3FgvKE5aNFBw4+hifOkyE0tywsDQVksdHA3jFRzcU9toFiJAz6nhPsBKDf5JlzJiIXhbNMtydoWtuuE7w==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-symbols": "~0.4.4",
     "expo-system-ui": "~5.0.7",
     "expo-web-browser": "~14.1.6",
+    "expo-auth-session": "^6.1.5",
     "firebase": "^11.8.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
## Summary
- add env vars for Google OAuth ids
- expose those IDs in app config
- implement login and register screens with Firebase auth
- support Google sign‑in
- show authenticated user in home screen

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840ba85f8b08324a044a58c863eb764